### PR TITLE
persistence: only use generic interface for global

### DIFF
--- a/BlasII.ModdingAPI/Main.cs
+++ b/BlasII.ModdingAPI/Main.cs
@@ -1,4 +1,5 @@
-﻿using MelonLoader;
+﻿using BlasII.ModdingAPI.Persistence;
+using MelonLoader;
 using System;
 using System.IO;
 using System.Reflection;
@@ -16,6 +17,7 @@ internal class Main : MelonMod
 
         ModLoader = new ModLoader();
         ModdingAPI = new ModdingAPI();
+        new TestMod();
     }
 
     public override void OnUpdate() => ModLoader.Update();

--- a/BlasII.ModdingAPI/ModdingAPI.cs
+++ b/BlasII.ModdingAPI/ModdingAPI.cs
@@ -12,9 +12,9 @@ using UnityEngine.UI;
 
 namespace BlasII.ModdingAPI;
 
-internal class ModdingAPI : BlasIIMod, IGlobalPersistentMod
+internal class ModdingAPI : BlasIIMod, IGlobalPersistentMod<TestGlobalSaveData>
 {
-    public System.Type GlobalDataType { get; } = typeof(TestGlobalSaveData);
+    //public System.Type GlobalDataType { get; } = typeof(TestGlobalSaveData);
 
     public ModdingAPI() : base(ModInfo.MOD_ID, ModInfo.MOD_NAME, ModInfo.MOD_AUTHOR, ModInfo.MOD_VERSION) { }
 

--- a/BlasII.ModdingAPI/ModdingAPI.cs
+++ b/BlasII.ModdingAPI/ModdingAPI.cs
@@ -18,14 +18,12 @@ internal class ModdingAPI : BlasIIMod, IGlobalPersistentMod<TestGlobalSaveData>
 
     public ModdingAPI() : base(ModInfo.MOD_ID, ModInfo.MOD_NAME, ModInfo.MOD_AUTHOR, ModInfo.MOD_VERSION) { }
 
-    public void Load(GlobalSaveData data)
+    public void LoadGlobal(TestGlobalSaveData data)
     {
-        TestGlobalSaveData testData = data as TestGlobalSaveData;
-
-        ModLog.Info("Loaded global: " + testData.Number);
+        ModLog.Info("Loaded global: " + data.Number);
     }
 
-    public GlobalSaveData Save()
+    public TestGlobalSaveData SaveGlobal()
     {
         ModLog.Info("Saved global: " + Time.frameCount);
         return new TestGlobalSaveData()

--- a/BlasII.ModdingAPI/ModdingAPI.cs
+++ b/BlasII.ModdingAPI/ModdingAPI.cs
@@ -4,7 +4,6 @@ using BlasII.ModdingAPI.Input;
 using BlasII.ModdingAPI.Persistence;
 using Il2CppTGK.Game.Components.UI;
 using Il2CppTMPro;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
@@ -14,8 +13,6 @@ namespace BlasII.ModdingAPI;
 
 internal class ModdingAPI : BlasIIMod, IGlobalPersistentMod<TestGlobalSaveData>
 {
-    //public System.Type GlobalDataType { get; } = typeof(TestGlobalSaveData);
-
     public ModdingAPI() : base(ModInfo.MOD_ID, ModInfo.MOD_NAME, ModInfo.MOD_AUTHOR, ModInfo.MOD_VERSION) { }
 
     public void LoadGlobal(TestGlobalSaveData data)
@@ -46,58 +43,6 @@ internal class ModdingAPI : BlasIIMod, IGlobalPersistentMod<TestGlobalSaveData>
 
             if (VersionHelper.GameVersion == "Unknown")
                 FindGameVersion();
-        }
-    }
-
-    void old()
-    {
-        var dict = new Dictionary<string, GlobalSaveData>();
-
-        foreach (var mod in ModHelper.LoadedMods)
-        {
-            ModLog.Error(mod.Id);
-            //foreach (var x in mod.GetType().GetInterfaces())
-            //{
-            //    ModLog.Info(x.Name);
-            //    ModLog.Warn(x.GetGenericTypeDefinition());
-            //    ModLog.Warn(x.GetGenericArguments()[0].Name);
-            //}
-
-            //foreach (var @interface in mod.GetType().GetInterfaces())
-            //{
-            //    if (!@interface.IsGenericType || !@interface.GetGenericTypeDefinition().IsAssignableFrom(typeof(IGlobalPersistentMod<>)))
-            //        continue;
-
-            //    // This mod implements the interface and this is the type of save data
-            //    System.Type dataType = @interface.GetGenericArguments()[0];
-            //    ModLog.Warn(dataType.Name);
-
-
-            //}
-
-            //System.Type globalMod = mod.GetType().GetInterfaces()
-            //    .Where(i => i.IsGenericType)
-            //    .Select(i => i.GetGenericTypeDefinition())
-            //    .FirstOrDefault(i => i.IsAssignableFrom(typeof(IGlobalPersistentMod<>)));
-
-            //bool isGlobal = globalMod != null;
-            //ModLog.Info("IS gloval: " + isGlobal);
-
-            //if (isGlobal)
-            //{
-            //    ModLog.Warn("savedata type: " + globalMod.GetGenericArguments()[0].Name);
-
-            //    ModLog.Warn("Global mod: " + mod.Id);
-            //    foreach (var x in mod.GetType().GenericTypeArguments)
-            //        ModLog.Info(x.Name);
-            //}
-
-            //if (mod != this)
-            ////if (!mod.GetType().GetInterfaces().Contains(typeof(IGlobalPersistentMod<>)))
-            //    continue;
-
-            //typeof(IGlobalPersistentMod<>).MakeGenericType()
-            //GlobalSaveData data = ((IGlobalPersistentMod<>)mod).Save();
         }
     }
 

--- a/BlasII.ModdingAPI/Persistence/GlobalSaveData.cs
+++ b/BlasII.ModdingAPI/Persistence/GlobalSaveData.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 
 namespace BlasII.ModdingAPI.Persistence;
@@ -27,7 +28,7 @@ public class GlobalSaveData
             if (modType == null)
                 return;
 
-            var save = modType.GetMethod(nameof(IGlobalPersistentMod<GlobalSaveData>.SaveGlobal), System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+            var save = modType.GetMethod(nameof(IGlobalPersistentMod<GlobalSaveData>.SaveGlobal), BindingFlags.Instance | BindingFlags.Public);
             object data = save.Invoke(mod, []);
 
             sb.AppendLine(mod.Id);
@@ -81,7 +82,7 @@ public class GlobalSaveData
 
             GlobalSaveData data = JsonConvert.DeserializeObject(json, dataType) as GlobalSaveData;
 
-            var load = modType.GetMethod(nameof(IGlobalPersistentMod<GlobalSaveData>.LoadGlobal), System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+            var load = modType.GetMethod(nameof(IGlobalPersistentMod<GlobalSaveData>.LoadGlobal), BindingFlags.Instance | BindingFlags.Public);
             load.Invoke(mod, [data]);
         });
     }

--- a/BlasII.ModdingAPI/Persistence/GlobalSaveData.cs
+++ b/BlasII.ModdingAPI/Persistence/GlobalSaveData.cs
@@ -20,8 +20,6 @@ public class GlobalSaveData
 
         Main.ModLoader.ProcessModFunction(mod =>
         {
-            ModLog.Warn(mod.Id);
-
             Type modType = mod.GetType().GetInterfaces()
                 .Where(i => i.IsGenericType)
                 .FirstOrDefault(i => i.GetGenericTypeDefinition().IsAssignableFrom(typeof(IGlobalPersistentMod<>)));
@@ -56,7 +54,7 @@ public class GlobalSaveData
             string[] lines = File.ReadAllLines(GetGlobalDataPath());
             for (int i = 0; i < lines.Length - 1; i += 2)
             {
-                datas.Add(lines[0], lines[1]);
+                datas.Add(lines[i], lines[i + 1]);
             }
         }
         catch (Exception e)
@@ -66,8 +64,6 @@ public class GlobalSaveData
 
         Main.ModLoader.ProcessModFunction(mod =>
         {
-            ModLog.Info(mod.Id);
-
             Type modType = mod.GetType().GetInterfaces()
                 .Where(i => i.IsGenericType)
                 .FirstOrDefault(i => i.GetGenericTypeDefinition().IsAssignableFrom(typeof(IGlobalPersistentMod<>)));

--- a/BlasII.ModdingAPI/Persistence/IGlobalPersistentMod.cs
+++ b/BlasII.ModdingAPI/Persistence/IGlobalPersistentMod.cs
@@ -45,3 +45,24 @@ public class TestGlobalSaveData : GlobalSaveData
 {
     public int Number { get; set; }
 }
+
+public class TestMod : BlasIIMod, IGlobalPersistentMod<TestGlobalSaveData>
+{
+    public TestMod() : base("BlasII.Test", "Test mod", "None", "0.1.0")
+    {
+    }
+
+    public void LoadGlobal(TestGlobalSaveData data)
+    {
+        ModLog.Warn("Loaded test global data: " + data.Number);
+    }
+
+    public TestGlobalSaveData SaveGlobal()
+    {
+        return new TestGlobalSaveData()
+        {
+            Number = DateTime.Now.Minute
+        };
+    }
+}
+

--- a/BlasII.ModdingAPI/Persistence/IGlobalPersistentMod.cs
+++ b/BlasII.ModdingAPI/Persistence/IGlobalPersistentMod.cs
@@ -5,26 +5,39 @@ namespace BlasII.ModdingAPI.Persistence;
 /// <summary>
 /// A mod that saves data with the global save file
 /// </summary>
-public interface IGlobalPersistentMod
-{
-    ///// <summary>
-    ///// The type of the serialized data
-    ///// </summary>
-    //public Type GlobalDataType { get; }
+//public interface IGlobalPersistentMod
+//{
+//    ///// <summary>
+//    ///// The type of the serialized data
+//    ///// </summary>
+//    //public Type GlobalDataType { get; }
 
+//    ///// <summary>
+//    ///// Saves the global data to an object
+//    ///// </summary>
+//    //public GlobalSaveData SaveGlobal();
+
+//    ///// <summary>
+//    ///// Loads the global data from an object
+//    ///// </summary>
+//    //public void LoadGlobal(GlobalSaveData data);
+//}
+
+/// <summary>
+/// A mod that saves data with the global save file
+/// </summary>
+public interface IGlobalPersistentMod<TData> where TData : GlobalSaveData
+{
     /// <summary>
     /// Saves the global data to an object
     /// </summary>
-    public GlobalSaveData Save();
+    public TData SaveGlobal();
 
     /// <summary>
     /// Loads the global data from an object
     /// </summary>
-    public void Load(GlobalSaveData data);
+    public void LoadGlobal(TData data);
 }
-
-/// <inheritdoc/>
-public interface IGlobalPersistentMod<T> : IGlobalPersistentMod where T : GlobalSaveData { }
 
 
 // TEMP !!!

--- a/BlasII.ModdingAPI/Persistence/IGlobalPersistentMod.cs
+++ b/BlasII.ModdingAPI/Persistence/IGlobalPersistentMod.cs
@@ -7,10 +7,10 @@ namespace BlasII.ModdingAPI.Persistence;
 /// </summary>
 public interface IGlobalPersistentMod
 {
-    /// <summary>
-    /// The type of the serialized data
-    /// </summary>
-    public Type GlobalDataType { get; }
+    ///// <summary>
+    ///// The type of the serialized data
+    ///// </summary>
+    //public Type GlobalDataType { get; }
 
     /// <summary>
     /// Saves the global data to an object
@@ -22,6 +22,9 @@ public interface IGlobalPersistentMod
     /// </summary>
     public void Load(GlobalSaveData data);
 }
+
+/// <inheritdoc/>
+public interface IGlobalPersistentMod<T> : IGlobalPersistentMod where T : GlobalSaveData { }
 
 
 // TEMP !!!


### PR DESCRIPTION
Before there was the ungeneric and a generic derived interface.  Now there is only a generic one and it forces you to specify the data type.  Uses reflection to call save/load methods