### PR TITLE
persistence: remake slot savedata

### DIFF
--- a/BlasII.ModdingAPI/ModdingAPI.cs
+++ b/BlasII.ModdingAPI/ModdingAPI.cs
@@ -1,6 +1,7 @@
 ﻿using BlasII.ModdingAPI.Assets;
 using BlasII.ModdingAPI.Helpers;
 using BlasII.ModdingAPI.Input;
+using BlasII.ModdingAPI.Persistence;
 using Il2CppTGK.Game.Components.UI;
 using Il2CppTMPro;
 using System.Linq;
@@ -10,7 +11,7 @@ using UnityEngine.UI;
 
 namespace BlasII.ModdingAPI;
 
-internal class ModdingAPI : BlasIIMod
+internal class ModdingAPI : BlasIIMod, ISlotPersistentMod<ModdingAPI.TestSlotData>
 {
     public ModdingAPI() : base(ModInfo.MOD_ID, ModInfo.MOD_NAME, ModInfo.MOD_AUTHOR, ModInfo.MOD_VERSION) { }
 
@@ -113,5 +114,31 @@ internal class ModdingAPI : BlasIIMod
 
         string color = mod == this || mod.Name.EndsWith("Framework") ? "7CA7BF" : "D3D3D3";
         return $"<color=#{color}>{line}</color>";
+    }
+
+    public TestSlotData SaveSlot()
+    {
+        ModLog.Warn("Saving slot data: " + Time.frameCount);
+        return new TestSlotData()
+        {
+            Number = Time.frameCount,
+            Text = System.DateTime.Now.ToString("MM/dd/yyyy")
+        };
+    }
+
+    public void LoadSlot(TestSlotData data)
+    {
+        ModLog.Warn($"Frame: {data.Number} Date: {data.Text}");
+    }
+
+    public void ResetSlot()
+    {
+        ModLog.Warn("Resetting slot data");
+    }
+
+    public class TestSlotData : SlotSaveData
+    {
+        public int Number { get; set; }
+        public string Text { get; set; }
     }
 }

--- a/BlasII.ModdingAPI/ModdingAPI.cs
+++ b/BlasII.ModdingAPI/ModdingAPI.cs
@@ -1,7 +1,6 @@
 ﻿using BlasII.ModdingAPI.Assets;
 using BlasII.ModdingAPI.Helpers;
 using BlasII.ModdingAPI.Input;
-using BlasII.ModdingAPI.Persistence;
 using Il2CppTGK.Game.Components.UI;
 using Il2CppTMPro;
 using System.Linq;
@@ -11,7 +10,7 @@ using UnityEngine.UI;
 
 namespace BlasII.ModdingAPI;
 
-internal class ModdingAPI : BlasIIMod, ISlotPersistentMod<ModdingAPI.TestSlotData>
+internal class ModdingAPI : BlasIIMod
 {
     public ModdingAPI() : base(ModInfo.MOD_ID, ModInfo.MOD_NAME, ModInfo.MOD_AUTHOR, ModInfo.MOD_VERSION) { }
 
@@ -114,31 +113,5 @@ internal class ModdingAPI : BlasIIMod, ISlotPersistentMod<ModdingAPI.TestSlotDat
 
         string color = mod == this || mod.Name.EndsWith("Framework") ? "7CA7BF" : "D3D3D3";
         return $"<color=#{color}>{line}</color>";
-    }
-
-    public TestSlotData SaveSlot()
-    {
-        ModLog.Warn("Saving slot data: " + Time.frameCount);
-        return new TestSlotData()
-        {
-            Number = Time.frameCount,
-            Text = System.DateTime.Now.ToString("MM/dd/yyyy")
-        };
-    }
-
-    public void LoadSlot(TestSlotData data)
-    {
-        ModLog.Warn($"Frame: {data.Number} Date: {data.Text}");
-    }
-
-    public void ResetSlot()
-    {
-        ModLog.Warn("Resetting slot data");
-    }
-
-    public class TestSlotData : SlotSaveData
-    {
-        public int Number { get; set; }
-        public string Text { get; set; }
     }
 }

--- a/BlasII.ModdingAPI/Persistence/GlobalSaveData.cs
+++ b/BlasII.ModdingAPI/Persistence/GlobalSaveData.cs
@@ -26,9 +26,7 @@ public class GlobalSaveData
 
         Main.ModLoader.ProcessModFunction(mod =>
         {
-            Type modType = mod.GetType().GetInterfaces()
-                .Where(i => i.IsGenericType)
-                .FirstOrDefault(i => i.GetGenericTypeDefinition().IsAssignableFrom(typeof(IGlobalPersistentMod<>)));
+            Type modType = GetInterfaceType(mod);
 
             if (modType == null)
                 return;
@@ -76,9 +74,7 @@ public class GlobalSaveData
 
         Main.ModLoader.ProcessModFunction(mod =>
         {
-            Type modType = mod.GetType().GetInterfaces()
-                .Where(i => i.IsGenericType)
-                .FirstOrDefault(i => i.GetGenericTypeDefinition().IsAssignableFrom(typeof(IGlobalPersistentMod<>)));
+            Type modType = GetInterfaceType(mod);
 
             if (modType == null)
                 return;
@@ -137,6 +133,16 @@ public class GlobalSaveData
         {
             ModLog.Error($"Failed to delete global data: {e.GetType()}");
         }
+    }
+
+    /// <summary>
+    /// Returns the interface type if the mod implements it
+    /// </summary>
+    private static Type GetInterfaceType(BlasIIMod mod)
+    {
+        return mod.GetType().GetInterfaces()
+            .Where(i => i.IsGenericType)
+            .FirstOrDefault(i => i.GetGenericTypeDefinition().IsAssignableFrom(typeof(IGlobalPersistentMod<>)));
     }
 
     /// <summary>

--- a/BlasII.ModdingAPI/Persistence/GlobalSaveData.cs
+++ b/BlasII.ModdingAPI/Persistence/GlobalSaveData.cs
@@ -122,7 +122,7 @@ public class GlobalSaveData
     }
 
     /// <summary>
-    /// Deletes the modded global save file
+    /// Deletes the global save file
     /// </summary>
     internal static void Delete()
     {

--- a/BlasII.ModdingAPI/Persistence/ISlotPersistentMod.cs
+++ b/BlasII.ModdingAPI/Persistence/ISlotPersistentMod.cs
@@ -4,17 +4,17 @@ namespace BlasII.ModdingAPI.Persistence;
 /// <summary>
 /// Allows a mod to save and load persistent data with the game files
 /// </summary>
-public interface IPersistentMod
+public interface ISlotPersistentMod
 {
     /// <summary>
     /// Saves an object containing the mod's persistent data
     /// </summary>
-    public SaveData SaveGame();
+    public SlotSaveData SaveGame();
 
     /// <summary>
     /// Loads an object containing the mod's persistent data
     /// </summary>
-    public void LoadGame(SaveData data);
+    public void LoadGame(SlotSaveData data);
 
     /// <summary>
     /// Resets the mod's persistent data

--- a/BlasII.ModdingAPI/Persistence/ISlotPersistentMod.cs
+++ b/BlasII.ModdingAPI/Persistence/ISlotPersistentMod.cs
@@ -2,22 +2,22 @@
 namespace BlasII.ModdingAPI.Persistence;
 
 /// <summary>
-/// Allows a mod to save and load persistent data with the game files
+/// A mod that saves data with a slot's save file
 /// </summary>
-public interface ISlotPersistentMod
+public interface ISlotPersistentMod<TData> where TData : SlotSaveData
 {
     /// <summary>
-    /// Saves an object containing the mod's persistent data
+    /// Saves the slot data to an object
     /// </summary>
-    public SlotSaveData SaveGame();
+    public TData SaveSlot();
 
     /// <summary>
-    /// Loads an object containing the mod's persistent data
+    /// Loads the slot data from an object
     /// </summary>
-    public void LoadGame(SlotSaveData data);
+    public void LoadSlot(TData data);
 
     /// <summary>
-    /// Resets the mod's persistent data
+    /// Resets the slot data
     /// </summary>
-    public void ResetGame();
+    public void ResetSlot();
 }

--- a/BlasII.ModdingAPI/Persistence/PersistencePatches.cs
+++ b/BlasII.ModdingAPI/Persistence/PersistencePatches.cs
@@ -11,7 +11,7 @@ class SaveDataManager_ResetPersistence_Patch
 {
     public static void Postfix()
     {
-        SaveData.Reset();
+        SlotSaveData.Reset();
     }
 }
 
@@ -20,7 +20,7 @@ class SaveDataManager_SaveGame1_Patch
 {
     public static void Postfix()
     {
-        SaveData.Save(CoreCache.SaveData.CurrentSaveSlot);
+        SlotSaveData.Save(CoreCache.SaveData.CurrentSaveSlot);
     }
 }
 
@@ -29,7 +29,7 @@ class SaveDataManager_SaveGame2_Patch
 {
     public static void Postfix(int slot)
     {
-        SaveData.Save(slot);
+        SlotSaveData.Save(slot);
     }
 }
 
@@ -38,7 +38,7 @@ class SaveDataManager_SaveGameInEnding_Patch
 {
     public static void Postfix()
     {
-        SaveData.Save(CoreCache.SaveData.CurrentSaveSlot);
+        SlotSaveData.Save(CoreCache.SaveData.CurrentSaveSlot);
     }
 }
 
@@ -47,7 +47,7 @@ class SaveDataManager_LoadGame_Patch
 {
     public static void Postfix(int slot)
     {
-        SaveData.Load(slot);
+        SlotSaveData.Load(slot);
     }
 }
 
@@ -56,7 +56,7 @@ class SaveDataManager_LoadGameWithoutReset_Patch
 {
     public static void Postfix(int slot)
     {
-        SaveData.Load(slot);
+        SlotSaveData.Load(slot);
     }
 }
 
@@ -65,7 +65,7 @@ class SaveDataManager_DeleteSlot_Patch
 {
     public static void Postfix(int slot)
     {
-        SaveData.Delete(slot);
+        SlotSaveData.Delete(slot);
     }
 }
 
@@ -74,7 +74,7 @@ class SaveDataManager_CopySlot_Patch
 {
     public static void Postfix(int slotSrc, int slotDest)
     {
-        SaveData.Copy(slotSrc, slotDest);
+        SlotSaveData.Copy(slotSrc, slotDest);
     }
 }
 

--- a/BlasII.ModdingAPI/Persistence/SlotSaveData.cs
+++ b/BlasII.ModdingAPI/Persistence/SlotSaveData.cs
@@ -7,82 +7,98 @@ using System.IO;
 namespace BlasII.ModdingAPI.Persistence;
 
 /// <summary>
-/// Used to save and load persistent data for a mod
+/// Used to store data with a slot's save file
 /// </summary>
 public abstract class SlotSaveData
 {
     /// <summary>
-    /// Resets game progress for each mod
+    /// Resets the slot's save file for all persistent mods
     /// </summary>
     internal static void Reset()
     {
-        ModLog.Custom($"Resetting data for all slots", Color.Blue);
+        //ModLog.Custom($"Resetting data for all slots", Color.Blue);
 
-        Main.ModLoader.ProcessModFunction(mod =>
-        {
-            if (mod is ISlotPersistentMod persistentMod)
-                persistentMod.ResetSlot();
-        });
+        //Main.ModLoader.ProcessModFunction(mod =>
+        //{
+        //    if (mod is ISlotPersistentMod persistentMod)
+        //        persistentMod.ResetSlot();
+        //});
     }
 
     /// <summary>
-    /// Saves game progress for each mod
+    /// Saves the slot's save file for all persistent mods
     /// </summary>
     internal static void Save(int slot)
     {
-        ModLog.Custom($"Saving data for slot {slot}", Color.Blue);
-        var data = new Dictionary<string, SlotSaveData>();
+        //ModLog.Custom($"Saving data for slot {slot}", Color.Blue);
+        //var data = new Dictionary<string, SlotSaveData>();
 
-        Main.ModLoader.ProcessModFunction(mod =>
-        {
-            if (mod is ISlotPersistentMod persistentMod)
-                data.Add(mod.Id, persistentMod.SaveSlot());
-        });
+        //Main.ModLoader.ProcessModFunction(mod =>
+        //{
+        //    if (mod is ISlotPersistentMod persistentMod)
+        //        data.Add(mod.Id, persistentMod.SaveSlot());
+        //});
 
-        try
-        {
-            string json = JsonConvert.SerializeObject(data, new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.Auto
-            });
-            File.WriteAllText(GetPathForSlot(slot), json);
-        }
-        catch (Exception e)
-        {
-            ModLog.Error($"Failed to save data for slot {slot}: {e.GetType()}");
-        }
+        //try
+        //{
+        //    string json = JsonConvert.SerializeObject(data, new JsonSerializerSettings
+        //    {
+        //        TypeNameHandling = TypeNameHandling.Auto
+        //    });
+        //    File.WriteAllText(GetPathForSlot(slot), json);
+        //}
+        //catch (Exception e)
+        //{
+        //    ModLog.Error($"Failed to save data for slot {slot}: {e.GetType()}");
+        //}
     }
 
     /// <summary>
-    /// Loads game progress for each mod
+    /// Saves the json to the slot's save file
+    /// </summary>
+    private static void SaveFile(Dictionary<string, string> datas)
+    {
+
+    }
+
+    /// <summary>
+    /// Loads the slot's save file for all persistent mods
     /// </summary>
     internal static void Load(int slot)
     {
-        ModLog.Custom($"Loading data for slot {slot}", Color.Blue);
-        var data = new Dictionary<string, SlotSaveData>();
+        //ModLog.Custom($"Loading data for slot {slot}", Color.Blue);
+        //var data = new Dictionary<string, SlotSaveData>();
 
-        try
-        {
-            string json = File.ReadAllText(GetPathForSlot(slot));
-            data = JsonConvert.DeserializeObject<Dictionary<string, SlotSaveData>>(json, new JsonSerializerSettings
-            {
-                TypeNameHandling = TypeNameHandling.Auto
-            });
-        }
-        catch (Exception e)
-        {
-            ModLog.Error($"Failed to load data for slot {slot}: {e.GetType()}");
-        }
+        //try
+        //{
+        //    string json = File.ReadAllText(GetPathForSlot(slot));
+        //    data = JsonConvert.DeserializeObject<Dictionary<string, SlotSaveData>>(json, new JsonSerializerSettings
+        //    {
+        //        TypeNameHandling = TypeNameHandling.Auto
+        //    });
+        //}
+        //catch (Exception e)
+        //{
+        //    ModLog.Error($"Failed to load data for slot {slot}: {e.GetType()}");
+        //}
 
-        Main.ModLoader.ProcessModFunction(mod =>
-        {
-            if (mod is ISlotPersistentMod persistentMod && data.TryGetValue(mod.Id, out SlotSaveData save))
-                persistentMod.LoadSlot(save);
-        });
+        //Main.ModLoader.ProcessModFunction(mod =>
+        //{
+        //    if (mod is ISlotPersistentMod persistentMod && data.TryGetValue(mod.Id, out SlotSaveData save))
+        //        persistentMod.LoadSlot(save);
+        //});
     }
 
     /// <summary>
-    /// Deletes the modded save data when the main save file is deleted
+    /// Loads the json from the slot's save file
+    /// </summary>
+    private static Dictionary<string, string> LoadFile()
+    {
+        return null;
+    }
+
+    /// <summary>
+    /// Deletes the slot's save file
     /// </summary>
     internal static void Delete(int slot)
     {
@@ -100,7 +116,7 @@ public abstract class SlotSaveData
     }
 
     /// <summary>
-    /// Copies the modded save data when the main save file is copied
+    /// Copies the slot's save file
     /// </summary>
     internal static void Copy(int slotSrc, int slotDest)
     {
@@ -119,7 +135,7 @@ public abstract class SlotSaveData
     }
 
     /// <summary>
-    /// Based on the slot number, calculates the file path for the modded save data
+    /// Returns the file path of the slot's save file
     /// </summary>
     private static string GetPathForSlot(int slot)
     {

--- a/BlasII.ModdingAPI/Persistence/SlotSaveData.cs
+++ b/BlasII.ModdingAPI/Persistence/SlotSaveData.cs
@@ -9,7 +9,7 @@ namespace BlasII.ModdingAPI.Persistence;
 /// <summary>
 /// Used to save and load persistent data for a mod
 /// </summary>
-public abstract class SaveData
+public abstract class SlotSaveData
 {
     /// <summary>
     /// Resets game progress for each mod
@@ -20,7 +20,7 @@ public abstract class SaveData
 
         Main.ModLoader.ProcessModFunction(mod =>
         {
-            if (mod is IPersistentMod persistentMod)
+            if (mod is ISlotPersistentMod persistentMod)
                 persistentMod.ResetGame();
         });
     }
@@ -31,11 +31,11 @@ public abstract class SaveData
     internal static void Save(int slot)
     {
         ModLog.Custom($"Saving data for slot {slot}", Color.Blue);
-        var data = new Dictionary<string, SaveData>();
+        var data = new Dictionary<string, SlotSaveData>();
 
         Main.ModLoader.ProcessModFunction(mod =>
         {
-            if (mod is IPersistentMod persistentMod)
+            if (mod is ISlotPersistentMod persistentMod)
                 data.Add(mod.Id, persistentMod.SaveGame());
         });
 
@@ -59,12 +59,12 @@ public abstract class SaveData
     internal static void Load(int slot)
     {
         ModLog.Custom($"Loading data for slot {slot}", Color.Blue);
-        var data = new Dictionary<string, SaveData>();
+        var data = new Dictionary<string, SlotSaveData>();
 
         try
         {
             string json = File.ReadAllText(GetPathForSlot(slot));
-            data = JsonConvert.DeserializeObject<Dictionary<string, SaveData>>(json, new JsonSerializerSettings
+            data = JsonConvert.DeserializeObject<Dictionary<string, SlotSaveData>>(json, new JsonSerializerSettings
             {
                 TypeNameHandling = TypeNameHandling.Auto
             });
@@ -76,7 +76,7 @@ public abstract class SaveData
 
         Main.ModLoader.ProcessModFunction(mod =>
         {
-            if (mod is IPersistentMod persistentMod && data.TryGetValue(mod.Id, out SaveData save))
+            if (mod is ISlotPersistentMod persistentMod && data.TryGetValue(mod.Id, out SlotSaveData save))
                 persistentMod.LoadGame(save);
         });
     }

--- a/BlasII.ModdingAPI/Persistence/SlotSaveData.cs
+++ b/BlasII.ModdingAPI/Persistence/SlotSaveData.cs
@@ -21,7 +21,7 @@ public abstract class SlotSaveData
         Main.ModLoader.ProcessModFunction(mod =>
         {
             if (mod is ISlotPersistentMod persistentMod)
-                persistentMod.ResetGame();
+                persistentMod.ResetSlot();
         });
     }
 
@@ -36,7 +36,7 @@ public abstract class SlotSaveData
         Main.ModLoader.ProcessModFunction(mod =>
         {
             if (mod is ISlotPersistentMod persistentMod)
-                data.Add(mod.Id, persistentMod.SaveGame());
+                data.Add(mod.Id, persistentMod.SaveSlot());
         });
 
         try
@@ -77,7 +77,7 @@ public abstract class SlotSaveData
         Main.ModLoader.ProcessModFunction(mod =>
         {
             if (mod is ISlotPersistentMod persistentMod && data.TryGetValue(mod.Id, out SlotSaveData save))
-                persistentMod.LoadGame(save);
+                persistentMod.LoadSlot(save);
         });
     }
 


### PR DESCRIPTION
- Breaking changes from renaming classes
- Redo slot persistence to be similar to global persistence
- All existing saves (Randomizer only at this point) will break